### PR TITLE
Fixed favorites comic number bug

### DIFF
--- a/app/src/main/java/de/tap/easy_xkcd/FavoritesFragment.java
+++ b/app/src/main/java/de/tap/easy_xkcd/FavoritesFragment.java
@@ -495,7 +495,7 @@ public class FavoritesFragment extends android.support.v4.app.Fragment {
 
             for (int i = 0; i < sFavorites.length; i++) {
                 sFavorites[i] = Integer.parseInt(mFav[i]);
-                mComicMap.put(i, new OfflineComic(i, getActivity()));
+                mComicMap.put(i, new OfflineComic(sFavorites[i], getActivity()));
                 /*try {
                     FileInputStream fis = getActivity().getApplicationContext().openFileInput(mFav[i]);
                     Bitmap mBitmap = BitmapFactory.decodeStream(fis);


### PR DESCRIPTION
The favorites were broken, because the wrong comic number was loaded . . .
Hope that fixed it!