### PR TITLE
Added "Open in browser" option to the comic browser

### DIFF
--- a/app/src/main/java/de/tap/easy_xkcd/fragments/ComicBrowserFragment.java
+++ b/app/src/main/java/de/tap/easy_xkcd/fragments/ComicBrowserFragment.java
@@ -455,6 +455,9 @@ public class ComicBrowserFragment extends android.support.v4.app.Fragment {
             case R.id.action_explain:
                 return explainComic(sLastComicNumber);
 
+            case R.id.action_browser:
+                return openInBrowser(sLastComicNumber);
+
             case R.id.action_trans:
                 return showTranscript();
         }
@@ -468,6 +471,12 @@ public class ComicBrowserFragment extends android.support.v4.app.Fragment {
         getActivity().getTheme().resolveAttribute(R.attr.colorPrimary, typedValue, true);
         intentBuilder.setToolbarColor(typedValue.data);
         CustomTabActivityHelper.openCustomTab(getActivity(), intentBuilder.build(), Uri.parse(url), new BrowserFallback());
+        return true;
+    }
+
+    private boolean openInBrowser(int number) {
+        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse("http://xkcd.com/" + String.valueOf(number)));
+        startActivity(intent);
         return true;
     }
 

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -64,6 +64,10 @@
         android:title="@string/action_explain"
         app:showAsAction="never" />
 
+    <item android:id="@+id/action_browser"
+        android:title="@string/action_browser"
+        app:showAsAction="never" />
+
     <item android:id="@+id/action_unread"
         android:title="@string/action_unread"
         android:visible="false"


### PR DESCRIPTION
I took the liberty of adding a "Open in Browser" option to the options menu in the ComicBrowserFragment.
This might come in handy if somebody wants to view one of the interactive comics in a normal web browser.