### PR TITLE
Added comic 1461 to the list of large comics

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -220,6 +220,7 @@
         <item>1298</item>
         <item>1389</item>
         <item>1392</item>
+        <item>1461</item>
         <item>1491</item>
     </integer-array>
 
@@ -241,6 +242,7 @@
         <item>http://imgs.xkcd.com/comics/exoplanet_neighborhood_large.png</item>
         <item>http://imgs.xkcd.com/comics/surface_area_large.png</item>
         <item>http://imgs.xkcd.com/comics/dominant_players_large.png</item>
+        <item>http://imgs.xkcd.com/comics/payloads_large.png</item>
         <item>http://imgs.xkcd.com/comics/stories_of_the_past_and_future_large.png</item>
     </string-array>
 


### PR DESCRIPTION
Comic 1461 was missing in the large_comics array, so I added it.

I also tried to add comic 1127 and 980, but comic 1127 lagged quite severely and comic 980 caused an OutOfMemoryError, which is why I decided to remove them again.