### PR TITLE
Add feature - Export Favorites list as text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added ability to export Favorites list as text (in Advanced settings)
+
 ## 4.0.1
 
 - Fixed crashes in 4.0

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A beautiful, fast, and easy to use [xkcd](http://xkcd.com/) reader for Android.
 * Notifications
 * Share comic url or image
 * Save a list of favorites
+* Export favorites list as text
 * Open links from xkcd.com and m.xkcd.com
 * Integration of [explain xkcd](http://www.explainxkcd.com) 
 * Night mode

--- a/app/src/main/java/de/tap/easy_xkcd/fragments/NestedPreferenceFragment.java
+++ b/app/src/main/java/de/tap/easy_xkcd/fragments/NestedPreferenceFragment.java
@@ -67,6 +67,7 @@ public class NestedPreferenceFragment extends PreferenceFragment {
     private static final String AUTO_NIGHT_END = "pref_auto_night_end";
     private static final String REPAIR = "pref_repair";
     private static final String MOBILE_ENABLED = "pref_update_mobile";
+	private static final String EXPORT = "pref_export";
     private static final String FAB_OPTIONS = "pref_random";
     private static final String OFFLINE_PATH_PREF = "pref_offline_path";
 
@@ -327,6 +328,27 @@ public class NestedPreferenceFragment extends PreferenceFragment {
                         } else {
                             Toast.makeText(getActivity(), R.string.no_connection, Toast.LENGTH_SHORT).show();
                         }
+                        return true;
+                    }
+                });
+                findPreference(EXPORT).setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
+                    @Override
+                    public boolean onPreferenceClick(Preference preference) {
+                        //Export the full favorites list as text                        
+                        String[] fav = Favorites.getFavoriteList(MainActivity.getInstance());
+                        StringBuilder sb = new StringBuilder();
+                        String newline = System.getProperty("line.separator");
+                        for (int i = 0; i < fav.length; i++) {
+                            sb.append(fav[i]).append(" - ");
+                            sb.append(prefHelper.getTitle(Integer.parseInt(fav[i])));
+                            sb.append(newline); 
+                        }
+                        //Provide option to send to any app that accepts text/plain content
+                        Intent sendIntent = new Intent(Intent.ACTION_SEND);
+                        sendIntent.putExtra(Intent.EXTRA_TEXT, sb.toString());
+                        sendIntent.setType("text/plain");
+                        //Always ask the user which app to send to, even if they've set a device default
+                        startActivity(Intent.createChooser(sendIntent, getResources().getString(R.string.pref_export)));
                         return true;
                     }
                 });

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -193,6 +193,8 @@
     <string name="pref_advanced">Rozšířené</string>
     <string name="pref_repair">Opravit offline komixy</string>
     <string name="pref_repair_sum">Pokud vidíte prázdné komixy, tato možnost je napraví novým stažením</string>
+    <string name="pref_export">Exportovat oblíbené položky</string>
+    <string name="pref_export_sum">Export seznamu Oblíbené jako text</string>
     <string name="pref_hide_donate">Skrýt tlačítko pro darování</string>
     <string name="title_activity_donate">Podpořit</string>
     <string name="pref_alt_title">Alternativní text</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -193,8 +193,8 @@
     <string name="pref_advanced">Rozšířené</string>
     <string name="pref_repair">Opravit offline komixy</string>
     <string name="pref_repair_sum">Pokud vidíte prázdné komixy, tato možnost je napraví novým stažením</string>
-    <string name="pref_export">Exportovat oblíbené položky</string>
-    <string name="pref_export_sum">Export seznamu Oblíbené jako text</string>
+    <string name="pref_export">Export Favorites</string>
+    <string name="pref_export_sum">Export your Favorites list as text</string>
     <string name="pref_hide_donate">Skrýt tlačítko pro darování</string>
     <string name="title_activity_donate">Podpořit</string>
     <string name="pref_alt_title">Alternativní text</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -209,6 +209,8 @@
     <string name="pref_zoom_sum">Kann Layout Probleme bei manchen Geräten beseitigen</string>
     <string name="pref_repair">Offline Comics reparieren</string>
     <string name="pref_repair_sum">Wenn du einige leere Comics siehst, benutze diese Option um sie neu herunterzuladen</string>
+    <string name="pref_export">Export Favoriten</string>
+    <string name="pref_export_sum">Exportieren Sie Ihre Favoriten-Liste als Text</string>
     <string name="action_donate">Spenden</string>
     <string name="dialog_donate">Wie viel möchtest du spenden?</string>
     <string name="pref_hide_donate">Spenden Button verstecken</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -209,8 +209,8 @@
     <string name="pref_zoom_sum">Kann Layout Probleme bei manchen Geräten beseitigen</string>
     <string name="pref_repair">Offline Comics reparieren</string>
     <string name="pref_repair_sum">Wenn du einige leere Comics siehst, benutze diese Option um sie neu herunterzuladen</string>
-    <string name="pref_export">Export Favoriten</string>
-    <string name="pref_export_sum">Exportieren Sie Ihre Favoriten-Liste als Text</string>
+    <string name="pref_export">Export Favorites</string>
+    <string name="pref_export_sum">Export your Favorites list as text</string>
     <string name="action_donate">Spenden</string>
     <string name="dialog_donate">Wie viel möchtest du spenden?</string>
     <string name="pref_hide_donate">Spenden Button verstecken</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -205,8 +205,8 @@
     <string name="pref_advanced">Напредно</string>
     <string name="pref_repair">Поправи локалне стрипове</string>
     <string name="pref_repair_sum">Ако видите празне стрипове, овом опцијом ћетепоново да их преузмете</string>
-    <string name="pref_export">Извоз Омиљене</string>
-    <string name="pref_export_sum">Извоз Васа листа Омиљених као текст</string>
+    <string name="pref_export">Export Favorites</string>
+    <string name="pref_export_sum">Export your Favorites list as text</string>
     <string name="pref_hide_donate">Сакриј дугме за донацију</string>
     <string name="title_activity_donate">Донирање</string>
     <string name="pref_alt_title">Алт текст</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -205,6 +205,8 @@
     <string name="pref_advanced">Напредно</string>
     <string name="pref_repair">Поправи локалне стрипове</string>
     <string name="pref_repair_sum">Ако видите празне стрипове, овом опцијом ћетепоново да их преузмете</string>
+    <string name="pref_export">Извоз Омиљене</string>
+    <string name="pref_export_sum">Извоз Васа листа Омиљених као текст</string>
     <string name="pref_hide_donate">Сакриј дугме за донацију</string>
     <string name="title_activity_donate">Донирање</string>
     <string name="pref_alt_title">Алт текст</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -312,6 +312,8 @@
     <string name="pref_advanced">Advanced</string>
     <string name="pref_repair">Repair offline comics</string>
     <string name="pref_repair_sum">If you see some blank comics, this option should fix it by re-downloading them</string>
+    <string name="pref_export">Export Favorites</string>
+    <string name="pref_export_sum">Export your Favorites list as text</string>
     <string name="pref_hide_donate">Hide donation button</string>
     <string name="title_activity_what_if" translatable="false">What if?</string>
     <string name="title_activity_donate">Donate</string>

--- a/app/src/main/res/xml/pref_advanced.xml
+++ b/app/src/main/res/xml/pref_advanced.xml
@@ -28,6 +28,12 @@
         android:summary="@string/pref_update_mobile_sum" />
 
     <Preference
+        android:key="pref_export"
+        android:title="@string/pref_export"
+        android:summary="@string/pref_export_sum"
+        />
+
+    <Preference
         android:key="pref_offline_path"
         android:persistent="false"
         android:title="@string/pref_offline_path"


### PR DESCRIPTION
Added ability to export favorites list as text. Available under the
Advanced settings. Exports in a format like this:
```
627 - Tech Support Cheat Sheet
641 - Free
645 - RPS
675 - Revolutionary
688 - Self-Description
```

The user can choose any app to export to that supports text/plain, such
as Gmail or a note-taking app.

Note that my computer and phone are not set up for Android development,
so I haven't tested or even compiled this, but it's a pretty simple
feature and hopefully I have done everything right. I used google
translate to add new text to the other languages, but I cannot vouch for
their accuracy.