### PR TITLE
Fixes #134 : app crash when removed from Favorites

### DIFF
--- a/app/src/main/java/de/tap/easy_xkcd/fragments/comics/FavoritesFragment.java
+++ b/app/src/main/java/de/tap/easy_xkcd/fragments/comics/FavoritesFragment.java
@@ -28,6 +28,7 @@ import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.design.widget.Snackbar;
+import android.support.v4.app.FragmentManager;
 import android.support.v4.content.FileProvider;
 import android.support.v4.view.ViewPager;
 import android.support.v7.widget.Toolbar;
@@ -389,6 +390,8 @@ public class FavoritesFragment extends ComicFragment {
                 //If there are no favorites left, show ComicBrowserFragment
                 MenuItem mBrowser = ((MainActivity) getActivity()).getNavView().getMenu().findItem(R.id.nav_browser);
                 ((MainActivity) getActivity()).selectDrawerItem(mBrowser, false, false);
+                FragmentManager fragmentManager = getActivity().getSupportFragmentManager();
+                fragmentManager.beginTransaction().remove(fragmentManager.findFragmentByTag("favorites")).commitAllowingStateLoss();
                 return;
             }
             refresh();


### PR DESCRIPTION
When there are no favorites the FavoritesFragment gets hidden and ComicBrowser is shown. The issue is resolved by removing FavoritesFragment from the activity instead of hiding it.