### PR TITLE
Use FileOutputStreams when building offline cache

### DIFF
--- a/app/src/main/java/de/tap/easy_xkcd/database/RealmComic.java
+++ b/app/src/main/java/de/tap/easy_xkcd/database/RealmComic.java
@@ -253,24 +253,19 @@ public class RealmComic extends RealmObject {
         }
     }
 
-    public static void saveOfflineBitmap(Response response, PrefHelper prefHelper, int number, Context context) {
+    public static void saveOfflineBitmap(Response response, PrefHelper prefHelper, int comicNumber, Context context) {
+        String comicFileName = comicNumber + ".png"; // TODO: Some early comics are .jpg
         try {
             File sdCard = prefHelper.getOfflinePath();
-            File dir = new File(sdCard.getAbsolutePath() + RealmComic.OFFLINE_PATH);
-            File file = new File(dir, number + ".png");
-            BufferedSink sink = Okio.buffer(Okio.sink(file));
-            sink.writeAll(response.body().source());
-            sink.close();
+            try (FileOutputStream fos = new FileOutputStream(sdCard.getAbsolutePath() + RealmComic.OFFLINE_PATH + comicFileName)) {
+                fos.write(response.body().bytes());
+            }
         } catch (Exception e) {
-            Timber.e("Error at comic %d: Saving to external storage failed: %s", number, e.getMessage());
-            try {
-                FileOutputStream fos = context.openFileOutput(String.valueOf(number), Context.MODE_PRIVATE);
-                BufferedSink sink = Okio.buffer(Okio.sink(fos));
-                sink.writeAll(response.body().source());
-                fos.close();
-                sink.close();
+            Timber.e("Error at comic %d: Saving to external storage failed: %s", comicNumber, e.getMessage());
+            try (FileOutputStream fos = context.openFileOutput(comicFileName, Context.MODE_PRIVATE)) {
+                fos.write(response.body().bytes());
             } catch (Exception e2) {
-                Timber.e("Error at comic %d: Saving to external storage failed: %s", number, e2.getMessage());
+                Timber.e("Error at comic %d: Saving to internal storage failed: %s", comicNumber, e2.getMessage());
             }
         } finally {
             response.body().close();
@@ -286,17 +281,18 @@ public class RealmComic extends RealmObject {
         }
 
         Bitmap mBitmap = null;
+        String comicFileName = comicNumber + ".png";
         try {
             File sdCard = prefHelper.getOfflinePath();
             File dir = new File(sdCard.getAbsolutePath() + OFFLINE_PATH);
-            File file = new File(dir, String.valueOf(comicNumber) + ".png");
+            File file = new File(dir, comicFileName);
             FileInputStream fis = new FileInputStream(file);
             mBitmap = BitmapFactory.decodeStream(fis);
             fis.close();
         } catch (IOException e) {
             Timber.e( "Image not found, looking in internal storage");
             try {
-                FileInputStream fis = context.openFileInput(String.valueOf(comicNumber));
+                FileInputStream fis = context.openFileInput(comicFileName);
                 mBitmap = BitmapFactory.decodeStream(fis);
                 fis.close();
             } catch (Exception e2) {

--- a/app/src/main/java/de/tap/easy_xkcd/database/RealmComic.java
+++ b/app/src/main/java/de/tap/easy_xkcd/database/RealmComic.java
@@ -235,7 +235,9 @@ public class RealmComic extends RealmObject {
             File sdCard = prefHelper.getOfflinePath();
             File dir = new File(sdCard.getAbsolutePath() + "/easy xkcd");
             //noinspection ResultOfMethodCallIgnored
-            dir.mkdirs();
+            if (!dir.exists()) {
+                dir.mkdirs();
+            }
             File file = new File(dir, String.valueOf(number) + ".png");
             FileOutputStream fos = new FileOutputStream(file);
             bitmap.compress(Bitmap.CompressFormat.PNG, 100, fos);
@@ -257,7 +259,11 @@ public class RealmComic extends RealmObject {
         String comicFileName = comicNumber + ".png"; // TODO: Some early comics are .jpg
         try {
             File sdCard = prefHelper.getOfflinePath();
-            try (FileOutputStream fos = new FileOutputStream(sdCard.getAbsolutePath() + RealmComic.OFFLINE_PATH + comicFileName)) {
+            File dir = new File(sdCard.getAbsolutePath() + RealmComic.OFFLINE_PATH);
+            if (!dir.exists()) {
+                dir.mkdirs();
+            }
+            try (FileOutputStream fos = new FileOutputStream(sdCard.getAbsolutePath() + RealmComic.OFFLINE_PATH + "/" + comicFileName)) {
                 fos.write(response.body().bytes());
             }
         } catch (Exception e) {

--- a/app/src/main/java/de/tap/easy_xkcd/database/updateComicDatabase.java
+++ b/app/src/main/java/de/tap/easy_xkcd/database/updateComicDatabase.java
@@ -71,7 +71,10 @@ public class updateComicDatabase extends AsyncTask<Void, String, Void> {
     void createNoMediaFile() {
         if (!prefHelper.nomediaCreated()) {
             File sdCard = prefHelper.getOfflinePath();
-            File dir = new File(sdCard.getAbsolutePath() + "/easy xkcd");
+            File dir = new File(sdCard.getAbsolutePath() + "/easy xkcd/");
+            if (!dir.exists()) {
+                dir.mkdirs();
+            }
             File nomedia = new File(dir, ".nomedia");
             try {
                 boolean created = nomedia.createNewFile();


### PR DESCRIPTION
I'm not sure why, but the Okio library used for writing files here consistently encountered a problem where the file stream was closed, even when writing to the internal cache. From quick testing, this properly saves the bitmaps and resolves https://github.com/T-Rex96/Easy_xkcd/issues/123 which I believe resulted from the bitmap not being fully saved